### PR TITLE
Created missing namespace for user class.

### DIFF
--- a/htpasswd/manifests/init.pp
+++ b/htpasswd/manifests/init.pp
@@ -1,1 +1,1 @@
-
+class htpasswd {}


### PR DESCRIPTION
Unable to instantiate the `user` class without the `htpasswd` namespace being defined. You get the following error prior to this change:

```
Could not find class htpasswd for <your server> at <line you include the htpasswd module> on node <your node>
```
